### PR TITLE
Fix Tests

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -27,7 +27,7 @@ gulp.task('nsp', function (cb) {
 });
 
 gulp.task('pre-test', function () {
-  return gulp.src('lib/*.js')
+  return gulp.src(['lib/*.js', '!lib/cli.js'])
     .pipe(istanbul({
       includeUntested: true,
       instrumenter: isparta.Instrumenter


### PR DESCRIPTION
cli.js breaks test because it looks like a shell script, so the first line does not parse in js. 
Ignoring it gets the tests working again.
